### PR TITLE
Update android plugin instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,7 @@ import com.codetrixstudio.capacitor.GoogleAuth.GoogleAuth;
 Register plugin inside your `MainActivity.onCreate`
 
 ```java
-this.init(savedInstanceState, new ArrayList<Class<? extends Plugin>>() {{
-  add(GoogleAuth.class);
-}});
+this.bridgeBuilder.addPlugin(GoogleAuth.class);
 ```
 
 ## Configure


### PR DESCRIPTION
Hello,

For android, this.init() has been depreciated for a while and is not even usable in the latest capacitor. 
I've updated the readme with the new way to add plug-ins.
